### PR TITLE
Update solved challenge styling in core-beta theme

### DIFF
--- a/ctfd/themes/core-beta/static/css/override.css
+++ b/ctfd/themes/core-beta/static/css/override.css
@@ -1,17 +1,17 @@
-.challenge-card.solved,
-.ctf-challenge.solved,
-.challenge-item.solved {
+:root {
+  --theme-solved: #FC6608;
+}
+
+.challenge-button.challenge-solved,
+[data-bs-theme="light"] .challenge-button.challenge-solved,
+[data-bs-theme="dark"] .challenge-button.challenge-solved {
   background-color: #FC6608 !important;
   color: #ffffff !important;
 }
 
-.challenge-card.solved:hover,
-.ctf-challenge.solved:hover,
-.challenge-item.solved:hover {
+.challenge-button.challenge-solved:hover,
+[data-bs-theme="light"] .challenge-button.challenge-solved:hover,
+[data-bs-theme="dark"] .challenge-button.challenge-solved:hover {
   background-color: #1A4085 !important;
   color: #ffffff !important;
-}
-
-:root {
-  --theme-solved: #FC6608;
 }

--- a/ctfd/themes/core-beta/templates/base.html
+++ b/ctfd/themes/core-beta/templates/base.html
@@ -10,6 +10,10 @@
 
   {% block stylesheets %}
     {{ Assets.css("assets/scss/main.scss") }}
+    <link
+      rel="stylesheet"
+      href="{{ url_for('views.themes', theme='core-beta', path='static/css/override.css') }}"
+    />
   {% endblock %}
 
   {{ Plugins.styles }}


### PR DESCRIPTION
## Summary
- include the theme override stylesheet so it is loaded with the core-beta assets
- update solved challenge button selectors to apply the new color palette and CSS variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19f48c7e48332af8ff164af38d121