### PR TITLE
Atualiza extração de traduções

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # ctf_clever
 Plataforma de CTF Fork do CTFD e do Chall-manager
+
+## Atualização de traduções
+
+Para extrair e atualizar as mensagens de tradução do projeto execute:
+
+```bash
+pybabel extract -F i18n/babel.cfg -o i18n/messages.pot .
+pybabel update -l pt_BR -i i18n/messages.pot -d i18n
+```
+
+Revise o diff gerado (`git diff`) e submeta as alterações resultantes.

--- a/challenges/containers/challenges/ctf_challenges_5/M20_log_forensics_tamper/app.py
+++ b/challenges/containers/challenges/ctf_challenges_5/M20_log_forensics_tamper/app.py
@@ -15,7 +15,7 @@ def bootstrap():
     LOG_DIR.mkdir(exist_ok=True)
     if not LOG_FILE.exists():
         LOG_FILE.write_text(
-            """2025-02-01 08:00:00;system;startup;engine online\n"
+            "2025-02-01 08:00:00;system;startup;engine online\n"
             "2025-02-01 08:10:12;audit;policy-check;no anomalies\n"
             f"2025-02-01 09:45:00;vault;flag;{FLAG}\n"
         )

--- a/i18n/babel.cfg
+++ b/i18n/babel.cfg
@@ -1,3 +1,7 @@
 [python: **.py]
-[jinja2: /templates/**.html]
+
+[jinja2: **/templates/**.html]
+extensions=jinja2.ext.do,jinja2.ext.loopcontrols
+
+[jinja2: **/templates/**.j2]
 extensions=jinja2.ext.do,jinja2.ext.loopcontrols

--- a/i18n/messages.pot
+++ b/i18n/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2025-10-04 21:49+0000\n"
+"POT-Creation-Date: 2025-10-04 22:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,4 +16,591 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
+
+#: ctfd/themes/admin/templates/macros/forms.html:50
+#: ctfd/themes/core-beta/templates/macros/forms.html:13
+#: ctfd/themes/core-beta/templates/macros/forms.html:36
+#: ctfd/themes/core-beta/templates/macros/forms.html:65
+msgid "(Optional)"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/base.html:53
+msgid "Powered by CECyber Play Labs"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:11
+#: ctfd/themes/core-beta/templates/teams/private.html:388
+#: ctfd/themes/core-beta/templates/teams/public.html:157
+#: ctfd/themes/core-beta/templates/users/private.html:124
+#: ctfd/themes/core-beta/templates/users/public.html:123
+msgid "Challenge"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:31
+msgid "Solution"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:41
+#, python-format
+msgid "%(num)d Solve"
+msgid_plural "%(num)d Solves"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:99
+msgid "View Hint"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:146
+msgid "attempt"
+msgid_plural "attempts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:161
+msgid "Flag"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:173
+msgid "Submit"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:195
+msgid "Next Challenge"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:201
+msgid "Share"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:232
+msgid "Submission"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:233
+msgid "Type"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:234
+#: ctfd/themes/core-beta/templates/challenge.html:263
+#: ctfd/themes/core-beta/templates/setup.html:305
+#: ctfd/themes/core-beta/templates/setup.html:326
+msgid "Date"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:262
+msgid "Name"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenges.html:7
+#: ctfd/themes/core-beta/templates/components/navbar.html:59
+msgid "Challenges"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:7
+msgid "Confirm"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:18
+msgid "We've sent a confirmation email to your email address."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:24
+msgid "Please click the link in that email to confirm your account."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:30
+msgid ""
+"If the email doesn’t arrive, check your spam folder or contact an "
+"administrator to manually verify your account."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:43
+msgid "Change Email Address"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:175
+#: ctfd/themes/core-beta/templates/components/navbar.html:180
+#: ctfd/themes/core-beta/templates/login.html:7
+msgid "Login"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/login.html:40
+msgid "Forgot your password?"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:85
+#: ctfd/themes/core-beta/templates/components/navbar.html:91
+#: ctfd/themes/core-beta/templates/notifications.html:7
+msgid "Notifications"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/notifications.html:14
+msgid "There are no notifications yet"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:162
+#: ctfd/themes/core-beta/templates/components/navbar.html:167
+#: ctfd/themes/core-beta/templates/register.html:7
+msgid "Register"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/register.html:35
+msgid "Your username on the site"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/register.html:43
+msgid "Never shown to the public"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/register.html:51
+msgid "Password used to log into your account"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/register.html:69
+#, python-format
+msgid ""
+"By registering, you agree to the <a href=\"%(privacy_link)s\" "
+"target=\"_blank\">privacy policy</a> and <a href=\"%(tos_link)s\" "
+"target=\"_blank\">terms of service</a>"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/reset_password.html:7
+msgid "Reset Password"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/reset_password.html:21
+msgid ""
+"You can now reset the password for your account and log in. Please enter "
+"in a new password below."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/reset_password.html:44
+msgid "Please provide the email address associated with your account below."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:52
+#: ctfd/themes/core-beta/templates/scoreboard.html:7
+msgid "Scoreboard"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/scoreboard.html:24
+msgid "All"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/scoreboard.html:36
+msgid "Place"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/scoreboard.html:38
+#: ctfd/themes/core-beta/templates/teams/private.html:330
+#: ctfd/themes/core-beta/templates/teams/public.html:96
+msgid "Score"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/scoreboard.html:60
+msgid "Scoreboard is empty"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:135
+#: ctfd/themes/core-beta/templates/components/navbar.html:140
+#: ctfd/themes/core-beta/templates/settings.html:8
+#: ctfd/themes/core-beta/templates/setup.html:50
+msgid "Settings"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:123
+#: ctfd/themes/core-beta/templates/components/navbar.html:128
+#: ctfd/themes/core-beta/templates/settings.html:21
+msgid "Profile"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:26
+msgid "Access Tokens"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:95
+msgid "Your profile has been updated"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:103
+#: ctfd/themes/core-beta/templates/teams/private.html:83
+#: ctfd/themes/core-beta/templates/teams/private.html:198
+msgid "Error:"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:129
+msgid "API Key Generated"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:137
+msgid "Please copy your API Key, it won't be shown again!"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:183
+msgid "Active Tokens"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:195
+msgid "Delete Token"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:204
+msgid "Are you sure you want to delete this token?"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:224
+msgid "Created"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:225
+msgid "Expiration"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:226
+msgid "Description"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:227
+msgid "Delete"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:24
+msgid "Setup"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:44
+msgid "General"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:47
+msgid "Mode"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:53
+msgid "Administration"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:56
+msgid "Style"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:59
+msgid "Date &amp; Time"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:62
+msgid "Integrations"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:86
+#: ctfd/themes/core-beta/templates/setup.html:138
+#: ctfd/themes/core-beta/templates/setup.html:202
+#: ctfd/themes/core-beta/templates/setup.html:238
+#: ctfd/themes/core-beta/templates/setup.html:296
+#: ctfd/themes/core-beta/templates/setup.html:345
+msgid "Next"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:112
+msgid "Participants register accounts and form teams"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:113
+msgid "If a team member solves a challenge, the entire team receives credit"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:115
+msgid "Easier to see which team member solved a challenge"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:116
+msgid "May be slightly more difficult to administer"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:120
+msgid "Participants only register an individual account"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:121
+msgid "Players can share accounts to form pseudo-teams"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:123
+msgid "Easier to organize"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:124
+msgid "Difficult to attribute solutions to individual team members"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:143
+msgid "Visibility Settings"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:146
+msgid "Control the visibility of different sections of CTFd"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:232
+msgid "Subscribe email address to the Cecyber Newsletter for news and updates"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:309
+#: ctfd/themes/core-beta/templates/setup.html:330
+#: ctfd/themes/core-beta/templates/teams/private.html:391
+#: ctfd/themes/core-beta/templates/teams/public.html:160
+#: ctfd/themes/core-beta/templates/users/private.html:127
+#: ctfd/themes/core-beta/templates/users/public.html:126
+msgid "Time"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:334
+msgid "UTC Preview"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:36
+#: ctfd/themes/core-beta/templates/users/users.html:6
+msgid "Users"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:43
+#: ctfd/themes/core-beta/templates/teams/teams.html:6
+msgid "Teams"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:72
+#: ctfd/themes/core-beta/templates/components/navbar.html:77
+msgid "Admin Panel"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:99
+#: ctfd/themes/core-beta/templates/components/navbar.html:104
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:6
+#: ctfd/themes/core-beta/templates/teams/teams.html:49
+msgid "Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:147
+#: ctfd/themes/core-beta/templates/components/navbar.html:152
+msgid "Logout"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:191
+msgid "Change language"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:210
+#: ctfd/themes/core-beta/templates/components/navbar.html:215
+msgid "Toggle theme"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/403.html:12
+msgid "403 Forbidden"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/404.html:9
+msgid "File not found"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/404.html:12
+msgid "404 Not Found"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/429.html:9
+msgid "Too many requests"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/429.html:10
+msgid "Please slow down!"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/429.html:13
+msgid "429 Too Many Requests"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/502.html:12
+msgid "502 Bad Gateway"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/invite.html:6
+#: ctfd/themes/core-beta/templates/teams/join_team.html:6
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:36
+msgid "Join Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/invite.html:15
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:12
+msgid "Welcome to"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/invite.html:19
+msgid "Click the button below to join the team!"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/new_team.html:6
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:39
+msgid "Create Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:8
+msgid "Edit Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:76
+msgid "Your team's profile has been updated"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:104
+msgid "Choose Captain"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:127
+msgid "Your captain rights have been transferred"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:152
+msgid "Invite Users"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:171
+msgid "Share this link with your team members for them to join your team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:174
+msgid "Invite links can be re-used and expire after 1 day"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:188
+msgid "Disband Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:193
+msgid "Are you sure you want to disband your team?"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:206
+msgid "No"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:207
+msgid "Yes"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:218
+#: ctfd/themes/core-beta/templates/teams/public.html:10
+#: ctfd/themes/core-beta/templates/users/private.html:21
+#: ctfd/themes/core-beta/templates/users/public.html:21
+#: ctfd/themes/core-beta/templates/users/users.html:70
+msgid "Official"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:260
+msgid "place"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:268
+msgid "points"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:325
+#: ctfd/themes/core-beta/templates/teams/public.html:91
+msgid "Members"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:329
+#: ctfd/themes/core-beta/templates/teams/public.html:95
+msgid "User Name"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:345
+#: ctfd/themes/core-beta/templates/teams/public.html:110
+msgid "Captain"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:361
+#: ctfd/themes/core-beta/templates/teams/public.html:125
+#: ctfd/themes/core-beta/templates/users/private.html:98
+#: ctfd/themes/core-beta/templates/users/public.html:98
+msgid "Awards"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:384
+#: ctfd/themes/core-beta/templates/teams/public.html:153
+#: ctfd/themes/core-beta/templates/users/private.html:120
+msgid "Solves"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:389
+#: ctfd/themes/core-beta/templates/teams/public.html:158
+#: ctfd/themes/core-beta/templates/users/private.html:125
+#: ctfd/themes/core-beta/templates/users/public.html:124
+msgid "Category"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:390
+#: ctfd/themes/core-beta/templates/teams/public.html:159
+#: ctfd/themes/core-beta/templates/users/private.html:126
+#: ctfd/themes/core-beta/templates/users/public.html:125
+msgid "Value"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:481
+#: ctfd/themes/core-beta/templates/teams/public.html:248
+#: ctfd/themes/core-beta/templates/users/private.html:213
+#: ctfd/themes/core-beta/templates/users/public.html:214
+msgid "No solves yet"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:14
+msgid "In order to participate you must either join or create a team."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:22
+msgid "Play with Official Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:27
+msgid "Join Unofficial Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:30
+msgid "Create Unofficial Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/teams.html:50
+#: ctfd/themes/core-beta/templates/users/users.html:47
+msgid "Website"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/teams.html:51
+#: ctfd/themes/core-beta/templates/users/users.html:48
+msgid "Affiliation"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/teams.html:52
+#: ctfd/themes/core-beta/templates/users/users.html:49
+msgid "Country"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/teams.html:128
+#: ctfd/themes/core-beta/templates/users/users.html:118
+msgid "Page"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/users/users.html:14
+#, python-format
+msgid ""
+"Searching for users with <strong>%(field)s</strong> matching "
+"<strong>%(q)s</strong>"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/users/users.html:17
+#, python-format
+msgid "Page %(page)s of %(total)s results"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/users/users.html:46
+msgid "User"
+msgstr ""
 

--- a/i18n/pt_BR/LC_MESSAGES/messages.po
+++ b/i18n/pt_BR/LC_MESSAGES/messages.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: itau-ctf\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-04 21:49+0000\n"
+"POT-Creation-Date: 2025-10-04 22:28+0000\n"
 "PO-Revision-Date: 2025-10-04 21:50+0000\n"
 "Last-Translator: \n"
 "Language-Team: pt_BR <LL@li.org>\n"
@@ -13,4 +13,591 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.17.0\n"
 "X-Note: Revisão humana obrigatória antes do deploy\n"
+
+#: ctfd/themes/admin/templates/macros/forms.html:50
+#: ctfd/themes/core-beta/templates/macros/forms.html:13
+#: ctfd/themes/core-beta/templates/macros/forms.html:36
+#: ctfd/themes/core-beta/templates/macros/forms.html:65
+msgid "(Optional)"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/base.html:53
+msgid "Powered by CECyber Play Labs"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:11
+#: ctfd/themes/core-beta/templates/teams/private.html:388
+#: ctfd/themes/core-beta/templates/teams/public.html:157
+#: ctfd/themes/core-beta/templates/users/private.html:124
+#: ctfd/themes/core-beta/templates/users/public.html:123
+msgid "Challenge"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:31
+msgid "Solution"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:41
+#, python-format
+msgid "%(num)d Solve"
+msgid_plural "%(num)d Solves"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:99
+msgid "View Hint"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:146
+msgid "attempt"
+msgid_plural "attempts"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:161
+msgid "Flag"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:173
+msgid "Submit"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:195
+msgid "Next Challenge"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:201
+msgid "Share"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:232
+msgid "Submission"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:233
+msgid "Type"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:234
+#: ctfd/themes/core-beta/templates/challenge.html:263
+#: ctfd/themes/core-beta/templates/setup.html:305
+#: ctfd/themes/core-beta/templates/setup.html:326
+msgid "Date"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenge.html:262
+msgid "Name"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/challenges.html:7
+#: ctfd/themes/core-beta/templates/components/navbar.html:59
+msgid "Challenges"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:7
+msgid "Confirm"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:18
+msgid "We've sent a confirmation email to your email address."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:24
+msgid "Please click the link in that email to confirm your account."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:30
+msgid ""
+"If the email doesn’t arrive, check your spam folder or contact an "
+"administrator to manually verify your account."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/confirm.html:43
+msgid "Change Email Address"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:175
+#: ctfd/themes/core-beta/templates/components/navbar.html:180
+#: ctfd/themes/core-beta/templates/login.html:7
+msgid "Login"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/login.html:40
+msgid "Forgot your password?"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:85
+#: ctfd/themes/core-beta/templates/components/navbar.html:91
+#: ctfd/themes/core-beta/templates/notifications.html:7
+msgid "Notifications"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/notifications.html:14
+msgid "There are no notifications yet"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:162
+#: ctfd/themes/core-beta/templates/components/navbar.html:167
+#: ctfd/themes/core-beta/templates/register.html:7
+msgid "Register"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/register.html:35
+msgid "Your username on the site"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/register.html:43
+msgid "Never shown to the public"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/register.html:51
+msgid "Password used to log into your account"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/register.html:69
+#, python-format
+msgid ""
+"By registering, you agree to the <a href=\"%(privacy_link)s\" "
+"target=\"_blank\">privacy policy</a> and <a href=\"%(tos_link)s\" "
+"target=\"_blank\">terms of service</a>"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/reset_password.html:7
+msgid "Reset Password"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/reset_password.html:21
+msgid ""
+"You can now reset the password for your account and log in. Please enter "
+"in a new password below."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/reset_password.html:44
+msgid "Please provide the email address associated with your account below."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:52
+#: ctfd/themes/core-beta/templates/scoreboard.html:7
+msgid "Scoreboard"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/scoreboard.html:24
+msgid "All"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/scoreboard.html:36
+msgid "Place"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/scoreboard.html:38
+#: ctfd/themes/core-beta/templates/teams/private.html:330
+#: ctfd/themes/core-beta/templates/teams/public.html:96
+msgid "Score"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/scoreboard.html:60
+msgid "Scoreboard is empty"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:135
+#: ctfd/themes/core-beta/templates/components/navbar.html:140
+#: ctfd/themes/core-beta/templates/settings.html:8
+#: ctfd/themes/core-beta/templates/setup.html:50
+msgid "Settings"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:123
+#: ctfd/themes/core-beta/templates/components/navbar.html:128
+#: ctfd/themes/core-beta/templates/settings.html:21
+msgid "Profile"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:26
+msgid "Access Tokens"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:95
+msgid "Your profile has been updated"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:103
+#: ctfd/themes/core-beta/templates/teams/private.html:83
+#: ctfd/themes/core-beta/templates/teams/private.html:198
+msgid "Error:"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:129
+msgid "API Key Generated"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:137
+msgid "Please copy your API Key, it won't be shown again!"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:183
+msgid "Active Tokens"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:195
+msgid "Delete Token"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:204
+msgid "Are you sure you want to delete this token?"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:224
+msgid "Created"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:225
+msgid "Expiration"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:226
+msgid "Description"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/settings.html:227
+msgid "Delete"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:24
+msgid "Setup"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:44
+msgid "General"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:47
+msgid "Mode"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:53
+msgid "Administration"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:56
+msgid "Style"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:59
+msgid "Date &amp; Time"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:62
+msgid "Integrations"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:86
+#: ctfd/themes/core-beta/templates/setup.html:138
+#: ctfd/themes/core-beta/templates/setup.html:202
+#: ctfd/themes/core-beta/templates/setup.html:238
+#: ctfd/themes/core-beta/templates/setup.html:296
+#: ctfd/themes/core-beta/templates/setup.html:345
+msgid "Next"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:112
+msgid "Participants register accounts and form teams"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:113
+msgid "If a team member solves a challenge, the entire team receives credit"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:115
+msgid "Easier to see which team member solved a challenge"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:116
+msgid "May be slightly more difficult to administer"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:120
+msgid "Participants only register an individual account"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:121
+msgid "Players can share accounts to form pseudo-teams"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:123
+msgid "Easier to organize"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:124
+msgid "Difficult to attribute solutions to individual team members"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:143
+msgid "Visibility Settings"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:146
+msgid "Control the visibility of different sections of CTFd"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:232
+msgid "Subscribe email address to the Cecyber Newsletter for news and updates"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:309
+#: ctfd/themes/core-beta/templates/setup.html:330
+#: ctfd/themes/core-beta/templates/teams/private.html:391
+#: ctfd/themes/core-beta/templates/teams/public.html:160
+#: ctfd/themes/core-beta/templates/users/private.html:127
+#: ctfd/themes/core-beta/templates/users/public.html:126
+msgid "Time"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/setup.html:334
+msgid "UTC Preview"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:36
+#: ctfd/themes/core-beta/templates/users/users.html:6
+msgid "Users"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:43
+#: ctfd/themes/core-beta/templates/teams/teams.html:6
+msgid "Teams"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:72
+#: ctfd/themes/core-beta/templates/components/navbar.html:77
+msgid "Admin Panel"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:99
+#: ctfd/themes/core-beta/templates/components/navbar.html:104
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:6
+#: ctfd/themes/core-beta/templates/teams/teams.html:49
+msgid "Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:147
+#: ctfd/themes/core-beta/templates/components/navbar.html:152
+msgid "Logout"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:191
+msgid "Change language"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/components/navbar.html:210
+#: ctfd/themes/core-beta/templates/components/navbar.html:215
+msgid "Toggle theme"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/403.html:12
+msgid "403 Forbidden"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/404.html:9
+msgid "File not found"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/404.html:12
+msgid "404 Not Found"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/429.html:9
+msgid "Too many requests"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/429.html:10
+msgid "Please slow down!"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/429.html:13
+msgid "429 Too Many Requests"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/errors/502.html:12
+msgid "502 Bad Gateway"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/invite.html:6
+#: ctfd/themes/core-beta/templates/teams/join_team.html:6
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:36
+msgid "Join Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/invite.html:15
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:12
+msgid "Welcome to"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/invite.html:19
+msgid "Click the button below to join the team!"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/new_team.html:6
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:39
+msgid "Create Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:8
+msgid "Edit Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:76
+msgid "Your team's profile has been updated"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:104
+msgid "Choose Captain"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:127
+msgid "Your captain rights have been transferred"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:152
+msgid "Invite Users"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:171
+msgid "Share this link with your team members for them to join your team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:174
+msgid "Invite links can be re-used and expire after 1 day"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:188
+msgid "Disband Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:193
+msgid "Are you sure you want to disband your team?"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:206
+msgid "No"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:207
+msgid "Yes"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:218
+#: ctfd/themes/core-beta/templates/teams/public.html:10
+#: ctfd/themes/core-beta/templates/users/private.html:21
+#: ctfd/themes/core-beta/templates/users/public.html:21
+#: ctfd/themes/core-beta/templates/users/users.html:70
+msgid "Official"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:260
+msgid "place"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:268
+msgid "points"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:325
+#: ctfd/themes/core-beta/templates/teams/public.html:91
+msgid "Members"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:329
+#: ctfd/themes/core-beta/templates/teams/public.html:95
+msgid "User Name"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:345
+#: ctfd/themes/core-beta/templates/teams/public.html:110
+msgid "Captain"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:361
+#: ctfd/themes/core-beta/templates/teams/public.html:125
+#: ctfd/themes/core-beta/templates/users/private.html:98
+#: ctfd/themes/core-beta/templates/users/public.html:98
+msgid "Awards"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:384
+#: ctfd/themes/core-beta/templates/teams/public.html:153
+#: ctfd/themes/core-beta/templates/users/private.html:120
+msgid "Solves"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:389
+#: ctfd/themes/core-beta/templates/teams/public.html:158
+#: ctfd/themes/core-beta/templates/users/private.html:125
+#: ctfd/themes/core-beta/templates/users/public.html:124
+msgid "Category"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:390
+#: ctfd/themes/core-beta/templates/teams/public.html:159
+#: ctfd/themes/core-beta/templates/users/private.html:126
+#: ctfd/themes/core-beta/templates/users/public.html:125
+msgid "Value"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/private.html:481
+#: ctfd/themes/core-beta/templates/teams/public.html:248
+#: ctfd/themes/core-beta/templates/users/private.html:213
+#: ctfd/themes/core-beta/templates/users/public.html:214
+msgid "No solves yet"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:14
+msgid "In order to participate you must either join or create a team."
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:22
+msgid "Play with Official Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:27
+msgid "Join Unofficial Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/team_enrollment.html:30
+msgid "Create Unofficial Team"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/teams.html:50
+#: ctfd/themes/core-beta/templates/users/users.html:47
+msgid "Website"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/teams.html:51
+#: ctfd/themes/core-beta/templates/users/users.html:48
+msgid "Affiliation"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/teams.html:52
+#: ctfd/themes/core-beta/templates/users/users.html:49
+msgid "Country"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/teams/teams.html:128
+#: ctfd/themes/core-beta/templates/users/users.html:118
+msgid "Page"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/users/users.html:14
+#, python-format
+msgid ""
+"Searching for users with <strong>%(field)s</strong> matching "
+"<strong>%(q)s</strong>"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/users/users.html:17
+#, python-format
+msgid "Page %(page)s of %(total)s results"
+msgstr ""
+
+#: ctfd/themes/core-beta/templates/users/users.html:46
+msgid "User"
+msgstr ""
 


### PR DESCRIPTION
## Summary
- aponta o babel.cfg para todos os diretórios de templates Jinja do repositório
- corrige um arquivo Python inválido que impedia a extração das mensagens
- regenera messages.pot/messages.po e documenta no README o fluxo para atualizar traduções

## Testing
- pybabel extract -F i18n/babel.cfg -o i18n/messages.pot .
- pybabel update -l pt_BR -i i18n/messages.pot -d i18n

------
https://chatgpt.com/codex/tasks/task_e_68e19f4cee148332975f50aa93ffdbc9